### PR TITLE
Add pretty encode for config JSON.

### DIFF
--- a/loh.cabal
+++ b/loh.cabal
@@ -28,7 +28,10 @@ Library
                         split,
                         time,
                         aeson,
-                        bytestring
+                        bytestring,
+                        vector,
+                        text,
+                        unordered-containers
 
   HS-Source-Dirs:       src/libloh/, src/libmocp/, src/
 


### PR DESCRIPTION
If we want user to change ~/.lohrc manually then we should give him this opportunity by generating this .rc file in some human readable format.
Proposed format is two-spaces indentation and egypt braces for arrays and objects.
