### PR TITLE
Remove redundant liblastfm responses wrapper.

### DIFF
--- a/src/libloh/Loh/Eventer.hs
+++ b/src/libloh/Loh/Eventer.hs
@@ -65,8 +65,8 @@ servePlayer c ρ maybeOldTrack = do
         else do
           stnp ← nowPlaying c new
           case stnp of
-            OperationDone → logNowPlaying ρ new
-            OperationFailed → logNowPlayingFailed ρ new
+            Right _ → logNowPlaying ρ new
+            Left _ → logNowPlayingFailed ρ new
           let delayToScrobble = round . (* 0.51) . toRational $ totalSec new
           -- logMessageP ρ $ "waiting " ++ show delayToScrobble ++ " toScrobble"
           isSameTrack ← followUntilReadyToScrobble ρ new delayToScrobble
@@ -74,8 +74,8 @@ servePlayer c ρ maybeOldTrack = do
             then do
               st ← scrobbleTrack c new
               case st of
-                OperationDone → logScrobble ρ new
-                OperationFailed → do
+                Right _ → logScrobble ρ new
+                Left _ → do
                   logScrobbleFailed ρ new
                   logDBStore ρ new
                   store new

--- a/src/libloh/Loh/LastFM/Method.hs
+++ b/src/libloh/Loh/LastFM/Method.hs
@@ -6,22 +6,23 @@ import Control.Applicative ((<$>))
 import Data.Time (formatTime, getCurrentTime)
 import System.Locale (defaultTimeLocale)
 
+import Network.Lastfm (Lastfm, Response)
 import qualified Network.Lastfm as LFM
 import qualified Network.Lastfm.JSON.Track as Track
 
 import Loh.Types
 
 
-loveTrack ∷ LFMConfig → TrackInfo → IO LFMOperationStatus
+loveTrack ∷ LFMConfig → TrackInfo → Lastfm Response
 loveTrack (ak, sk, s) ti =
-  toLFMStatus <$> Track.love
+  Track.love
     (LFM.Artist $ artist ti)
     (LFM.Track $ track ti)
     ak sk s
 
-nowPlaying ∷ LFMConfig → TrackInfo → IO LFMOperationStatus
+nowPlaying ∷ LFMConfig → TrackInfo →  Lastfm Response
 nowPlaying (ak, sk, s) ti =
-  toLFMStatus <$> Track.updateNowPlaying
+  Track.updateNowPlaying
     (LFM.Artist $ artist ti)
     (LFM.Track $ track ti)
     (Just $ LFM.Album $ album ti)
@@ -32,10 +33,10 @@ nowPlaying (ak, sk, s) ti =
     (Just $ LFM.Duration $ totalSec ti)
     ak sk s
 
-scrobbleTrack ∷ LFMConfig → TrackInfo → IO LFMOperationStatus
+scrobbleTrack ∷ LFMConfig → TrackInfo → Lastfm Response
 scrobbleTrack (ak, sk, s) ti = do
   nts ← read . formatTime defaultTimeLocale "%s" <$> getCurrentTime
-  toLFMStatus <$> Track.scrobble
+  Track.scrobble
     ( LFM.Timestamp nts
     , Just $ LFM.Album $ album ti
     , LFM.Artist $ artist ti
@@ -48,8 +49,3 @@ scrobbleTrack (ak, sk, s) ti = do
     , Nothing
     , Nothing
     ) ak sk s
-
-
-toLFMStatus ∷ Either α β → LFMOperationStatus
-toLFMStatus =
-  either (const OperationFailed) (const OperationDone)

--- a/src/libloh/Loh/Types.hs
+++ b/src/libloh/Loh/Types.hs
@@ -39,6 +39,3 @@ data PlayerName = Mocp | Mpd
   deriving (Eq, Ord, Read, Show)
 
 type LFMConfig = (LFM.APIKey, LFM.SessionKey, LFM.Secret)
-
-data LFMOperationStatus = OperationDone | OperationFailed
-  deriving (Eq)


### PR DESCRIPTION
We will need this change when curl errors would be treated differently from Lastfm API errors.  
With current wrappers that would be impossible.
