### PR TITLE
Add debug flag to cabal file for convenient use.

### DIFF
--- a/loh.cabal
+++ b/loh.cabal
@@ -15,6 +15,10 @@ Build-type:             Simple
 Cabal-version:          >= 1.6
 Homepage:               https://github.com/dmalikov/loh
 
+flag debug
+  description: Enable DEBUG logging.
+  default: False
+
 Library
   Build-Depends:        base >= 3 && < 5,
                         containers,
@@ -64,3 +68,5 @@ Executable              loh
   Main-is:              Loh.hs
   HS-Source-Dirs:       src/libloh/, src/libmocp/
   Extensions:           UnicodeSyntax
+  if flag(debug)
+    CPP-Options: -D__DEBUG__

--- a/src/libloh/Loh.hs
+++ b/src/libloh/Loh.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 
@@ -16,6 +17,14 @@ import Loh.Config (LConfig(..), readConfig, writeConfig)
 import Loh.Eventer
 
 
+debugLevel ∷ Priority
+#ifdef __DEBUG__
+debugLevel = DEBUG
+#else
+debugLevel = INFO
+#endif
+
+
 main ∷ IO ()
 main = do
   decodedConfig ← catch readConfig $ \(_ ∷ SomeException) → genConfigSkeleton
@@ -23,7 +32,7 @@ main = do
     Just config → do
       handler ← streamHandler stderr DEBUG >>= \lh → return $
         setFormatter lh (tfLogFormatter "%F %T" "[$time] ($prio) $loggername: $msg")
-      updateGlobalLogger "" (setLevel INFO . setHandlers [handler])
+      updateGlobalLogger "" (setLevel debugLevel . setHandlers [handler])
       eventer config
     Nothing → error "Malformed ~/.lohrc"
 


### PR DESCRIPTION
This way we can say to imaginary user install Loh via `cabal install Loh --flags=debug` if he has some issues with Loh and then collect some debug logs from his machine without making him change sources.
